### PR TITLE
Remove port from default `MPD_HOST` warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ impl MPDLibrary {
                 Some((password, host)) => (Some(password.to_owned()), host.to_owned()),
             },
             Err(_) => {
-                warn!("Could not find any MPD_HOST environment variable set. Defaulting to 127.0.0.1:6600.");
+                warn!("Could not find any MPD_HOST environment variable set. Defaulting to 127.0.0.1.");
                 (None, String::from("127.0.0.1"))
             }
         };


### PR DESCRIPTION
Right now, if both `MPD_HOST` and `MPD_PORT` environment variables are not set, you would get two warnings, e.g.:

> [2024-01-08T08:54:08Z WARN  blissify] Could not find any MPD_HOST environment variable set. Defaulting to 127.0.0.1:6600.
> [2024-01-08T08:54:08Z WARN  blissify] Could not find any MPD_PORT environment variable set. Defaulting to 6600.

where the port 6600 is repeated in both messages. This can be misleading in case the user has only `MPD_PORT` set to e.g. 6601 - the user would get the first warning:

> [2024-01-08T08:54:08Z WARN  blissify] Could not find any MPD_HOST environment variable set. Defaulting to 127.0.0.1:6600.

but blissify would be acutally connecting on the 6601 port, which would be misleading.

Also, in the code, the port [is not being set](https://github.com/Polochon-street/blissify-rs/blob/24871111ba903c07f5db44584dca21c3d6bd15e3/src/main.rs#L143) when `MPD_HOST` is not set.